### PR TITLE
fix repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "https://github.com/mixonic/ember-cli-deprecation-workflow/",
+  "repository": "https://github.com/ember-cli/ember-cli-deprecation-workflow/",
   "license": "MIT",
   "author": "",
   "directories": {


### PR DESCRIPTION
this fixes the release process and updates the link in npm

the automatic github releases fails without this change: https://github.com/ember-cli/ember-cli-deprecation-workflow/actions/runs/9889225039/job/27314811230
