### PR TITLE
Support RegExp for matchId

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -26,6 +26,13 @@ setupDeprecationWorkflow({
 let postamble = `  ]
 });`;
 
+function matchesWorkflow(matcher, value) {
+  return (
+    (typeof matcher === 'string' && matcher === value) ||
+    (matcher instanceof RegExp && matcher.exec(value))
+  );
+}
+
 export function detectWorkflow(config, message, options) {
   if (!config || !config.workflow) {
     return;
@@ -38,10 +45,8 @@ export function detectWorkflow(config, message, options) {
     idMatcher = workflow.matchId;
 
     if (
-      (typeof idMatcher === 'string' && options && idMatcher === options.id) ||
-      (idMatcher instanceof RegExp && idMatcher.exec(options.id)) ||
-      (typeof matcher === 'string' && matcher === message) ||
-      (matcher instanceof RegExp && matcher.exec(message))
+      matchesWorkflow(idMatcher, options?.id) ||
+      matchesWorkflow(matcher, message)
     ) {
       return workflow;
     }

--- a/addon/index.js
+++ b/addon/index.js
@@ -37,11 +37,12 @@ export function detectWorkflow(config, message, options) {
     matcher = workflow.matchMessage;
     idMatcher = workflow.matchId;
 
-    if (typeof idMatcher === 'string' && options && idMatcher === options.id) {
-      return workflow;
-    } else if (typeof matcher === 'string' && matcher === message) {
-      return workflow;
-    } else if (matcher instanceof RegExp && matcher.exec(message)) {
+    if (
+      (typeof idMatcher === 'string' && options && idMatcher === options.id) ||
+      (idMatcher instanceof RegExp && idMatcher.exec(options.id)) ||
+      (typeof matcher === 'string' && matcher === message) ||
+      (matcher instanceof RegExp && matcher.exec(message))
+    ) {
       return workflow;
     }
   }

--- a/tests/unit/handle-deprecation-workflow-test.js
+++ b/tests/unit/handle-deprecation-workflow-test.js
@@ -318,4 +318,76 @@ module('handleDeprecationWorkflow', function (hooks) {
       );
     }, 'deprecation throws');
   });
+
+  test('deprecation silenced with id regex', function (assert) {
+    const config = {
+      throwOnUnhandled: true,
+      workflow: [{ matchId: /^ember\..*/, handler: 'silence' }],
+    };
+
+    handleDeprecationWorkflow(
+      config,
+      'Slightly interesting',
+      {
+        id: 'ember.deprecation-workflow',
+        since: 'the beginning',
+        until: '3.0.0',
+        for: 'testing',
+      },
+      () => {},
+    );
+
+    assert.ok(true, 'Deprecation did not raise');
+  });
+
+  // eslint-disable-next-line qunit/require-expect
+  test('deprecation logs with id regex', function (assert) {
+    assert.expect(1);
+
+    let message = 'Slightly interesting';
+
+    console.warn = function (passedMessage) {
+      assert.strictEqual(
+        passedMessage,
+        'DEPRECATION: ' + message,
+        'deprecation logs',
+      );
+    };
+
+    const config = {
+      throwOnUnhandled: true,
+      workflow: [{ matchId: /^ember\..*/, handler: 'log' }],
+    };
+
+    handleDeprecationWorkflow(
+      config,
+      'Slightly interesting',
+      {
+        id: 'ember.deprecation-workflow',
+        since: 'the beginning',
+        until: '3.0.0',
+        for: 'testing',
+      },
+      () => {},
+    );
+  });
+
+  test('deprecation thrown with id regex', function (assert) {
+    const config = {
+      workflow: [{ matchId: /^ember\..*/, handler: 'throw' }],
+    };
+    assert.throws(function () {
+      handleDeprecationWorkflow(
+        config,
+        'Slightly interesting',
+        {
+          id: 'ember.deprecation-workflow',
+          since: 'the beginning',
+          until: '3.0.0',
+          for: 'testing',
+        },
+        () => {},
+      );
+    }, 'deprecation throws');
+  });
 });

--- a/tests/unit/handle-deprecation-workflow-test.js
+++ b/tests/unit/handle-deprecation-workflow-test.js
@@ -87,6 +87,7 @@ module('handleDeprecationWorkflow', function (hooks) {
 
   test('deprecation silenced with string matcher', function (assert) {
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchMessage: 'Interesting', handler: 'silence' }],
     };
 
@@ -113,6 +114,7 @@ module('handleDeprecationWorkflow', function (hooks) {
     };
 
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchMessage: message, handler: 'log' }],
     };
 
@@ -151,6 +153,7 @@ module('handleDeprecationWorkflow', function (hooks) {
 
   test('deprecation silenced with regex matcher', function (assert) {
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchMessage: /Inter/, handler: 'silence' }],
     };
 
@@ -184,6 +187,7 @@ module('handleDeprecationWorkflow', function (hooks) {
     };
 
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchMessage: /Inter/, handler: 'log' }],
     };
 
@@ -245,6 +249,7 @@ module('handleDeprecationWorkflow', function (hooks) {
 
   test('deprecation silenced with id matcher', function (assert) {
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchId: 'ember.deprecation-workflow', handler: 'silence' }],
     };
 
@@ -278,6 +283,7 @@ module('handleDeprecationWorkflow', function (hooks) {
     };
 
     const config = {
+      throwOnUnhandled: true,
       workflow: [{ matchId: 'ember.deprecation-workflow', handler: 'log' }],
     };
 


### PR DESCRIPTION
The `matchMessage` config already supports passing a Regex, this is adding the same capability for `matchId`.