### PR TITLE
Allow passing a custom handler to flushDeprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ addressing a single deprecation at a time, and prevents backsliding
 
 4. Run your test suite\* with `ember test --server`.
 5. Navigate to your tests (default: http://localhost:7357/)
-6. Run `deprecationWorkflow.flushDeprecations()` in your browsers console.
+6. Run `deprecationWorkflow.flushDeprecations()` in your browsers console. Or `flushDeprecations({ handler: 'log' })` if you want a different [handler](#handlers) than the default of `silence`.
 7. Copy the string output and overwrite the content of `app/deprecation-workflow.js`.
 
     In Chrome, use right click → "Copy string contents" to avoid escape characters.

--- a/addon/index.js
+++ b/addon/index.js
@@ -51,8 +51,10 @@ export function flushDeprecations() {
   let messages = self.deprecationWorkflow.deprecationLog.messages;
   let logs = [];
 
-  for (let message in messages) {
-    logs.push(messages[message]);
+  for (let [deprecation, matcher] of Object.entries(messages)) {
+    logs.push(
+      `    { handler: "silence", ${matcher}: ${JSON.stringify(deprecation)} }`,
+    );
   }
 
   let deprecations = logs.join(',\n') + '\n';
@@ -107,8 +109,7 @@ export function deprecationCollector(message, options, next) {
   let key = (options && options.id) || message;
   let matchKey = options && key === options.id ? 'matchId' : 'matchMessage';
 
-  self.deprecationWorkflow.deprecationLog.messages[key] =
-    '    { handler: "silence", ' + matchKey + ': ' + JSON.stringify(key) + ' }';
+  self.deprecationWorkflow.deprecationLog.messages[key] = matchKey;
 
   next(message, options);
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -47,13 +47,15 @@ export function detectWorkflow(config, message, options) {
   }
 }
 
-export function flushDeprecations() {
+export function flushDeprecations({ handler = 'silence' } = {}) {
   let messages = self.deprecationWorkflow.deprecationLog.messages;
   let logs = [];
 
   for (let [deprecation, matcher] of Object.entries(messages)) {
     logs.push(
-      `    { handler: "silence", ${matcher}: ${JSON.stringify(deprecation)} }`,
+      `    { handler: ${JSON.stringify(handler)}, ${matcher}: ${JSON.stringify(
+        deprecation,
+      )} }`,
     );
   }
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,7 +5,7 @@ const LOG_LIMIT = 100;
 export default function setupDeprecationWorkflow(config) {
   self.deprecationWorkflow = self.deprecationWorkflow || {};
   self.deprecationWorkflow.deprecationLog = {
-    messages: {},
+    messages: new Set(),
   };
 
   registerDeprecationHandler((message, options, next) =>
@@ -51,10 +51,10 @@ export function flushDeprecations({ handler = 'silence' } = {}) {
   let messages = self.deprecationWorkflow.deprecationLog.messages;
   let logs = [];
 
-  for (let [deprecation, matcher] of Object.entries(messages)) {
+  for (let id of messages.values()) {
     logs.push(
-      `    { handler: ${JSON.stringify(handler)}, ${matcher}: ${JSON.stringify(
-        deprecation,
+      `    { handler: ${JSON.stringify(handler)}, matchId: ${JSON.stringify(
+        id,
       )} }`,
     );
   }
@@ -108,10 +108,7 @@ export function handleDeprecationWorkflow(config, message, options, next) {
 }
 
 export function deprecationCollector(message, options, next) {
-  let key = (options && options.id) || message;
-  let matchKey = options && key === options.id ? 'matchId' : 'matchMessage';
-
-  self.deprecationWorkflow.deprecationLog.messages[key] = matchKey;
+  self.deprecationWorkflow.deprecationLog.messages.add(options.id);
 
   next(message, options);
 }

--- a/tests/acceptance/flush-deprecations-test.js
+++ b/tests/acceptance/flush-deprecations-test.js
@@ -10,7 +10,7 @@ module('flushDeprecations', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    window.deprecationWorkflow.deprecationLog = { messages: {} };
+    window.deprecationWorkflow.deprecationLog = { messages: new Set() };
     window.Testem.handleConsoleMessage = originalWarn;
   });
 

--- a/tests/acceptance/workflow-config-test.js
+++ b/tests/acceptance/workflow-config-test.js
@@ -12,7 +12,7 @@ module('workflow config', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    window.deprecationWorkflow.deprecationLog = { messages: {} };
+    window.deprecationWorkflow.deprecationLog = { messages: new Set() };
     window.Testem.handleConsoleMessage = originalWarn;
   });
 

--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -17,7 +17,7 @@ module('deprecationCollector', function (hooks) {
     originalConfig = self.deprecationWorkflow = {
       config: null,
       deprecationLog: {
-        messages: {},
+        messages: new Set(),
       },
     };
   });
@@ -50,10 +50,10 @@ module('deprecationCollector', function (hooks) {
       () => {},
     );
 
-    assert.deepEqual(self.deprecationWorkflow.deprecationLog.messages, {
-      first: 'matchId',
-      second: 'matchId',
-    });
+    assert.deepEqual(
+      self.deprecationWorkflow.deprecationLog.messages,
+      new Set(['first', 'second']),
+    );
   });
 
   test('should call next', function (assert) {
@@ -119,9 +119,9 @@ module('deprecationCollector', function (hooks) {
       () => {},
     );
 
-    assert.deepEqual(self.deprecationWorkflow.deprecationLog.messages, {
-      first: 'matchId',
-      second: 'matchId',
-    });
+    assert.deepEqual(
+      self.deprecationWorkflow.deprecationLog.messages,
+      new Set(['first', 'second']),
+    );
   });
 });

--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -51,8 +51,8 @@ module('deprecationCollector', function (hooks) {
     );
 
     assert.deepEqual(self.deprecationWorkflow.deprecationLog.messages, {
-      first: '    { handler: "silence", matchId: "first" }',
-      second: '    { handler: "silence", matchId: "second" }',
+      first: 'matchId',
+      second: 'matchId',
     });
   });
 
@@ -120,8 +120,8 @@ module('deprecationCollector', function (hooks) {
     );
 
     assert.deepEqual(self.deprecationWorkflow.deprecationLog.messages, {
-      first: '    { handler: "silence", matchId: "first" }',
-      second: '    { handler: "silence", matchId: "second" }',
+      first: 'matchId',
+      second: 'matchId',
     });
   });
 });

--- a/tests/unit/flush-deprecations-test.js
+++ b/tests/unit/flush-deprecations-test.js
@@ -16,22 +16,22 @@ module('flushDeprecations', function (hooks) {
     originalConfig = self.deprecationWorkflow = {
       config: null,
       deprecationLog: {
-        messages: [],
+        messages: new Set(),
       },
     };
   });
 
   hooks.afterEach(function () {
     self.deprecationWorkflow.config = originalConfig;
-    self.deprecationWorkflow.deprecationLog = { messages: {} };
+    self.deprecationWorkflow.deprecationLog = { messages: new Set() };
     console.warn = originalWarn;
   });
 
   test('calling flushDeprecations returns workflow config', function (assert) {
-    self.deprecationWorkflow.deprecationLog.messages = {
-      first: 'matchId',
-      second: 'matchId',
-    };
+    self.deprecationWorkflow.deprecationLog.messages = new Set([
+      'first',
+      'second',
+    ]);
 
     let deprecationsPayload = flushDeprecations();
     assert.strictEqual(
@@ -48,10 +48,10 @@ setupDeprecationWorkflow({
   });
 
   test('calling flushDeprecations with custom handler returns workflow config', function (assert) {
-    self.deprecationWorkflow.deprecationLog.messages = {
-      first: 'matchId',
-      second: 'matchId',
-    };
+    self.deprecationWorkflow.deprecationLog.messages = new Set([
+      'first',
+      'second',
+    ]);
 
     let deprecationsPayload = flushDeprecations({ handler: 'log' });
     assert.strictEqual(

--- a/tests/unit/flush-deprecations-test.js
+++ b/tests/unit/flush-deprecations-test.js
@@ -27,7 +27,7 @@ module('flushDeprecations', function (hooks) {
     console.warn = originalWarn;
   });
 
-  test('calling flushDeprecations returns string of deprecations', function (assert) {
+  test('calling flushDeprecations returns workflow config', function (assert) {
     self.deprecationWorkflow.deprecationLog.messages = {
       first: 'matchId',
       second: 'matchId',
@@ -42,6 +42,26 @@ setupDeprecationWorkflow({
   workflow: [
     { handler: "silence", matchId: "first" },
     { handler: "silence", matchId: "second" }
+  ]
+});`,
+    );
+  });
+
+  test('calling flushDeprecations with custom handler returns workflow config', function (assert) {
+    self.deprecationWorkflow.deprecationLog.messages = {
+      first: 'matchId',
+      second: 'matchId',
+    };
+
+    let deprecationsPayload = flushDeprecations({ handler: 'log' });
+    assert.strictEqual(
+      deprecationsPayload,
+      `import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
+
+setupDeprecationWorkflow({
+  workflow: [
+    { handler: "log", matchId: "first" },
+    { handler: "log", matchId: "second" }
   ]
 });`,
     );

--- a/tests/unit/flush-deprecations-test.js
+++ b/tests/unit/flush-deprecations-test.js
@@ -29,8 +29,8 @@ module('flushDeprecations', function (hooks) {
 
   test('calling flushDeprecations returns string of deprecations', function (assert) {
     self.deprecationWorkflow.deprecationLog.messages = {
-      first: '    { handler: "silence", matchId: "first" }',
-      second: '    { handler: "silence", matchId: "second" }',
+      first: 'matchId',
+      second: 'matchId',
     };
 
     let deprecationsPayload = flushDeprecations();


### PR DESCRIPTION
Running `flushDeprecations()` will always emit a config where all detected deprecations are silenced. But that is not always what you want. E.g. when you want your config to have `throwOnUnhandled` enabled, you might want to have all known deprecations to be listed (so they don't throw), but with a `log` handler.

This is now possible by running `flushDeprecations({ handler: 'log' })` instead. The default remains `silence`, so this is a non-breaking change.

-- 
Edit: 
Internally, this is removing support for deprecations that don't have an ID. Having an ID is asserted for since this [PR](https://github.com/emberjs/ember.js/pull/16934), which landed way before the earliest version of 3.28 which we support here.

This simplifies the internal collector logic, to just add IDs to a `Set` and always emitting a config with `matchId`, instead of having to support both `matchId` and `matchMessage` (which was only used when no ID was present)