### PR TITLE
flushDeprecations merges detected deprecations with existing config

### DIFF
--- a/tests/acceptance/flush-deprecations-test.js
+++ b/tests/acceptance/flush-deprecations-test.js
@@ -1,6 +1,7 @@
 import { deprecate } from '@ember/debug';
 import { module } from 'qunit';
 import test from '../helpers/debug-test';
+import { config } from 'dummy/deprecation-workflow';
 
 let originalWarn;
 
@@ -56,12 +57,19 @@ module('flushDeprecations', function (hooks) {
       deprecationsPayload,
       `import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
-setupDeprecationWorkflow({
-  workflow: [
-    { handler: "silence", matchId: "test" },
-    { handler: "silence", matchId: "log-strict" }
-  ]
-});`,
+setupDeprecationWorkflow(${JSON.stringify(
+        {
+          ...config,
+          workflow: [
+            ...config.workflow,
+            { handler: 'silence', matchId: 'test' },
+            // this one is already present in the existing config, so don't expect another entry, as we deduplicate
+            // { handler: 'silence', matchId: 'log-strict' },
+          ],
+        },
+        undefined,
+        2,
+      )});`,
     );
   });
 });

--- a/tests/dummy/app/deprecation-workflow.js
+++ b/tests/dummy/app/deprecation-workflow.js
@@ -1,6 +1,7 @@
 import setupDeprecationWorkflow from 'ember-cli-deprecation-workflow';
 
-setupDeprecationWorkflow({
+// We export this here to be able to import from our own tests
+export const config = {
   throwOnUnhandled: true,
   workflow: [
     /*
@@ -26,4 +27,6 @@ setupDeprecationWorkflow({
 
     { matchMessage: 'throw-strict', handler: 'throw' },
   ],
-});
+};
+
+setupDeprecationWorkflow(config);


### PR DESCRIPTION
Currently calling `flushDeprecations()` is destructive in that it ignores any existing config. Users would need to merge the detected deprecations with their existing config manually. Which is error prone, and does not scale for very large monorepos.

This change is doing the merge automatically. Only minor drawback is that we need to serialize the merged config with `JSON.serialize`, so it is getting returned with additional quotes e.g. `{ "handler": "silence", "matchId": "test" }` instead of `{ handler: 'silence', matchId: 'test' }`. But when using prettier, this will get auto-fixed anyway, so I think the trade-offs are positive here.