### PR TITLE
Options are optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
-export default function setupDeprecationWorkflow(config: {
-  throwOnUnhandled: boolean;
-  workflow: {
+export default function setupDeprecationWorkflow(config?: {
+  throwOnUnhandled?: boolean;
+  workflow?: {
     handler: 'log' | 'silence' | 'throw';
     matchId: string;
     matchMessage: string;


### PR DESCRIPTION
Upon updating to the latest I was pleasantly surprised to find types included, but couldn't use them because they incorrectly claim the options are all mandatory.