### PR TITLE
Fix type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,16 @@
+interface WorkflowMatchId {
+  handler?: 'log' | 'silence' | 'throw';
+  matchId: string | RegExp;
+}
+
+interface WorkflowMatchMessage {
+  handler?: 'log' | 'silence' | 'throw';
+  matchMessage: string | RegExp;
+}
+
+type Workflow = WorkflowMatchId | WorkflowMatchMessage;
+
 export default function setupDeprecationWorkflow(config?: {
   throwOnUnhandled?: boolean;
-  workflow?: {
-    handler: 'log' | 'silence' | 'throw';
-    matchId: string;
-    matchMessage: string;
-  }[];
+  workflow?: Workflow[];
 }): void;


### PR DESCRIPTION
`matchId` and `matchMessage` should be mutually exclusive., and both also accept a `RegExp`.