### PR TITLE
Correct ember-source compatibility for 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ addressing a single deprecation at a time, and prevents backsliding
 
 3.x
 
-- Ember.js 3.28 until at least 5.4
+- Ember.js 4.0 until at least 5.4
 - Ember CLI 4.12 or above
 - Node.js 16 or above
 


### PR DESCRIPTION
Just tried to use ember-cli-deprecation-workflow with an Ember 3.28.12 project, but it doesn't meet the peerDependency of ember-source >= 4.0.0

https://github.com/ember-cli/ember-cli-deprecation-workflow/blob/d70f32b0f30e63bf1722e8070ecddb3df434ecce/package.json#L78-L80

Updated the readme to make it clearer that ember-source 3.28 projects should use the 2.x line of this addon