### PR TITLE
Relax ember-source peerDependency for 3.28 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "webpack": "^5.89.0"
   },
   "peerDependencies": {
-    "ember-source": ">= 4.0.0"
+    "ember-source": ">= 3.28.0"
   },
   "engines": {
     "node": ">= 18"


### PR DESCRIPTION
Mentioned in #214 that v 3.x does work with ember-source 3.28