### PR TITLE
Throw Deprecation ID

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -101,7 +101,7 @@ export function handleDeprecationWorkflow(config, message, options, next) {
         break;
       }
       case 'throw':
-        throw new Error(message);
+        throw new Error(message + ` (id: ${options?.id || 'unknown'})`);
       default:
         next(message, options);
         break;


### PR DESCRIPTION
When using throw to catch deprecations it's really nice to have the ID along with the message.